### PR TITLE
Sync with upstream template improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A RemNote plugin that syncs books from a Goodreads RSS feed into RemNote as Rem documents. Built with TypeScript, React, and the RemNote Plugin SDK (https://plugins.remnote.com/).
+A RemNote plugin that syncs books from a Goodreads RSS feed into RemNote as Rem documents. Built with TypeScript, React, and the RemNote Plugin SDK (https://plugins.remnote.com/). This project follows Conventional Commits standards.
 
 ## Development Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remnote-goodreads-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remnote-goodreads-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@remnote/plugin-sdk": "latest",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check-types": "tsc",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --color --progress --no-open",
-    "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && shx cp README.md dist && cd dist && bestzip ../PluginZip.zip ./*"
+    "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && cd dist && bestzip ../PluginZip.zip ./*"
   },
   "dependencies": {
     "@remnote/plugin-sdk": "latest",

--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,0 @@
-/* Add your plugin styles here. */

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,1 @@
+/* Add your plugin styles here. This file is named <widget-name>.css; in this case, index.css*/

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -1,6 +1,6 @@
-import { declareIndexPlugin, ReactRNPlugin, Rem } from '@remnote/plugin-sdk';
+import { declareIndexPlugin, type ReactRNPlugin, Rem } from '@remnote/plugin-sdk';
 import '../style.css';
-import '../App.css';
+import '../index.css'; // import <widget-name>.css
 import { doError, doLog } from '../logging';
 import { GoodreadsBook, parseBooks } from '../parseRss';
 import { fetchRss } from '../fetchRss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,14 @@ const SANDBOX_SUFFIX = '-sandbox';
 
 const config = {
   mode: isProd ? 'production' : 'development',
-  entry: glob.sync('./src/widgets/**.tsx').reduce(function (obj, el) {
-    obj[path.parse(el).name] = el;
-    obj[path.parse(el).name + SANDBOX_SUFFIX] = el;
+  entry: glob.sync('./src/widgets/**/*.tsx').reduce((obj, el) => {
+    const rel = path
+      .relative('src/widgets', el)
+      .replace(/\.[tj]sx?$/, '')
+      .replace(/\\/g, '/');
+
+    obj[rel] = el;
+    obj[`${rel}${SANDBOX_SUFFIX}`] = el;
     return obj;
   }, {}),
 


### PR DESCRIPTION
## Summary

- Syncs with upstream remnote-plugin-template-react improvements from July 2025
- Enhances webpack configuration for better nested widget support
- Modernizes CSS file naming to follow widget conventions
- Updates TypeScript imports to use type-only imports
- Removes redundant build script steps

## Changes

### Webpack Configuration
- Enhanced entry glob pattern from `./src/widgets/**.tsx` to `./src/widgets/**/*.tsx`
- Improved path handling with `path.relative()` for nested directory support
- Added regex to properly strip file extensions
- Normalized backslashes for Windows compatibility

### CSS & Imports
- Renamed `src/App.css` → `src/index.css` to match widget naming convention
- Updated CSS import in index.tsx with explanatory comment
- Changed `ReactRNPlugin` → `type ReactRNPlugin` for better type-only imports

### Build Script
- Removed redundant `shx cp README.md dist` (handled by webpack CopyPlugin)

## Test plan

- [x] TypeScript type checking passes
- [x] Production build completes successfully
- [x] Plugin validation passes
- [x] CSS correctly outputs as `index.css`
- [x] README.md included in build via webpack

🤖 Generated with [Claude Code](https://claude.com/claude-code)