### PR TITLE
feat: nest imported books under parent Rem and downgrade permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remnote-goodreads-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remnote-goodreads-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@remnote/plugin-sdk": "latest",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,7 +15,8 @@
   "requestNative": false,
   "requiredScopes": [
     {
-      "type": "All",
+      "type": "DescendantsOfName",
+      "remName": "Goodreads Import",
       "level": "ReadCreateModify"
     }
   ],


### PR DESCRIPTION
## Summary
- Creates a "Goodreads Import" parent Rem and nests all imported book Rems under it
- Downgrades plugin permissions from `All` to `DescendantsOfName` scoped to the parent Rem
- Deduplication now checks within the parent Rem instead of globally

Fixes https://github.com/michaelgriscom/remnote-goodreads-plugin/issues/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)