### PR TITLE
feat: add author/book tags and auto-import authors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,10 @@ Before creating a Rem, the plugin checks if one with the same title already exis
 
 ### Tags and Author Linking
 
-The plugin creates "Book" and "Author" tag Rems under "Goodreads Import". The "Book" tag has an "Author(s)" child slot (created via `setIsSlot(true)`). When a book is imported:
-- The book Rem is tagged with "Book"
+The plugin creates "Book" and "Author" tag Rems under "Goodreads Import". A custom powerup (`bookPowerup`) registers an "Author(s)" multi-select property (sourced from Rems tagged "Author") on the Book tag. When a book is imported:
+- The book Rem is tagged with "Book" and given the `bookPowerup` powerup
 - An author Rem is created (if not already existing) and tagged with "Author"
-- A property child is added to the book whose text references the "Author(s)" slot and whose back text references the author Rem
+- The book's "Author(s)" property is set to a Rem reference pointing to the author
 
 Author Rems are deduplicated by name, so multiple books by the same author share a single author Rem.
 
@@ -59,9 +59,9 @@ This plugin uses `@remnote/plugin-sdk` to interact with RemNote:
 - `plugin.rem.createRem()` - Creates new Rem documents
 - `plugin.rem.findByName()` - Searches for existing Rems
 - `rem.addTag()` - Tags a Rem with another Rem
-- `rem.setIsSlot()` - Marks a child Rem as a property slot on a tag
-- `rem.setBackText()` - Sets the back text (property value) of a Rem
+- `rem.addPowerup()` / `rem.setPowerupProperty()` - Adds powerup slots and sets their values
 - `plugin.richText.rem().value()` - Builds rich text containing Rem references
+- `plugin.app.registerPowerup()` - Registers a custom powerup with typed property slots
 - `plugin.settings.registerStringSetting()` / `registerBooleanSetting()` - Adds user-configurable settings
 - `plugin.app.registerCommand()` - Registers commands in RemNote's command palette
 - `plugin.app.toast()` - Shows user notifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,10 @@ Before creating a Rem, the plugin checks if one with the same title already exis
 
 ### Tags and Author Linking
 
-The plugin creates "Book" and "Author" tag Rems under "Goodreads Import". A custom powerup (`bookPowerup`) defines an "Author(s)" slot on the Book tag. When a book is imported:
-- The book Rem is tagged with "Book" and given the `bookPowerup` powerup
+The plugin creates "Book" and "Author" tag Rems under "Goodreads Import". The "Book" tag has an "Author(s)" child slot (created via `setIsSlot(true)`). When a book is imported:
+- The book Rem is tagged with "Book"
 - An author Rem is created (if not already existing) and tagged with "Author"
-- The book's "Author(s)" property is set to a Rem reference pointing to the author
+- A property child is added to the book whose text references the "Author(s)" slot and whose back text references the author Rem
 
 Author Rems are deduplicated by name, so multiple books by the same author share a single author Rem.
 
@@ -59,9 +59,9 @@ This plugin uses `@remnote/plugin-sdk` to interact with RemNote:
 - `plugin.rem.createRem()` - Creates new Rem documents
 - `plugin.rem.findByName()` - Searches for existing Rems
 - `rem.addTag()` - Tags a Rem with another Rem
-- `rem.addPowerup()` / `rem.setPowerupProperty()` - Adds powerup slots and sets their values
+- `rem.setIsSlot()` - Marks a child Rem as a property slot on a tag
+- `rem.setBackText()` - Sets the back text (property value) of a Rem
 - `plugin.richText.rem().value()` - Builds rich text containing Rem references
-- `plugin.app.registerPowerup()` - Registers a custom powerup with named slots
 - `plugin.settings.registerStringSetting()` / `registerBooleanSetting()` - Adds user-configurable settings
 - `plugin.app.registerCommand()` - Registers commands in RemNote's command palette
 - `plugin.app.toast()` - Shows user notifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,15 +40,28 @@ The production plugin must be loaded in RemNote's environment which handles CORS
 
 Before creating a Rem, the plugin checks if one with the same title already exists using `plugin.rem.findByName()`. This prevents duplicate entries on repeated syncs.
 
+### Tags and Author Linking
+
+The plugin creates "Book" and "Author" tag Rems under "Goodreads Import". A custom powerup (`bookPowerup`) defines an "Author(s)" slot on the Book tag. When a book is imported:
+- The book Rem is tagged with "Book" and given the `bookPowerup` powerup
+- An author Rem is created (if not already existing) and tagged with "Author"
+- The book's "Author(s)" property is set to a Rem reference pointing to the author
+
+Author Rems are deduplicated by name, so multiple books by the same author share a single author Rem.
+
 ### Unused Data
 
-The RSS parser extracts comprehensive book metadata (author, cover URL, ratings, read dates, shelves, etc.) but currently only the `title` field is used for Rem creation. This data is available for future enhancements.
+The RSS parser extracts comprehensive book metadata (cover URL, ratings, read dates, shelves, etc.) beyond what is currently used (title, author). This data is available for future enhancements.
 
 ## RemNote Plugin SDK
 
 This plugin uses `@remnote/plugin-sdk` to interact with RemNote:
 - `plugin.rem.createRem()` - Creates new Rem documents
 - `plugin.rem.findByName()` - Searches for existing Rems
+- `rem.addTag()` - Tags a Rem with another Rem
+- `rem.addPowerup()` / `rem.setPowerupProperty()` - Adds powerup slots and sets their values
+- `plugin.richText.rem().value()` - Builds rich text containing Rem references
+- `plugin.app.registerPowerup()` - Registers a custom powerup with named slots
 - `plugin.settings.registerStringSetting()` / `registerBooleanSetting()` - Adds user-configurable settings
 - `plugin.app.registerCommand()` - Registers commands in RemNote's command palette
 - `plugin.app.toast()` - Shows user notifications

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@remnote/plugin-sdk": "latest",
+        "@remnote/plugin-sdk": "^0.0.46",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@remnote/plugin-sdk": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@remnote/plugin-sdk/-/plugin-sdk-0.0.14.tgz",
-      "integrity": "sha512-rIj6qkdeLgdk6SKz6Yq75sGJCYdZXjaD7o2TgqP9yQ3uhuu/aOyw/SmTajaiwkbOsgRkYfqQk0oJc/8+xBipyA==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@remnote/plugin-sdk/-/plugin-sdk-0.0.46.tgz",
+      "integrity": "sha512-LrHxLeIDFfrpCFgN2+0n/uhGpZU2gQhCBUD2dDCLBR3AsyV0w95KR6flx4woYitJbHCIlVod8ByqCheDua8HsQ==",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "enquirer": "^2.3.6",
@@ -330,7 +330,7 @@
         "os": "^0.1.2",
         "type-fest": "^2.12.1",
         "underscore": "^1.13.2",
-        "zod": "^3.17.10"
+        "zod": "^3.22.2"
       },
       "bin": {
         "remnote-plugin": "scripts/index.js"
@@ -6378,9 +6378,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6591,9 +6591,9 @@
       }
     },
     "@remnote/plugin-sdk": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@remnote/plugin-sdk/-/plugin-sdk-0.0.14.tgz",
-      "integrity": "sha512-rIj6qkdeLgdk6SKz6Yq75sGJCYdZXjaD7o2TgqP9yQ3uhuu/aOyw/SmTajaiwkbOsgRkYfqQk0oJc/8+xBipyA==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@remnote/plugin-sdk/-/plugin-sdk-0.0.46.tgz",
+      "integrity": "sha512-LrHxLeIDFfrpCFgN2+0n/uhGpZU2gQhCBUD2dDCLBR3AsyV0w95KR6flx4woYitJbHCIlVod8ByqCheDua8HsQ==",
       "requires": {
         "ansi-colors": "^4.1.3",
         "enquirer": "^2.3.6",
@@ -6602,7 +6602,7 @@
         "os": "^0.1.2",
         "type-fest": "^2.12.1",
         "underscore": "^1.13.2",
-        "zod": "^3.17.10"
+        "zod": "^3.22.2"
       }
     },
     "@tsconfig/node10": {
@@ -11133,9 +11133,9 @@
       }
     },
     "zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remnote-goodreads-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remnote-goodreads-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@remnote/plugin-sdk": "latest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && cd dist && bestzip ../PluginZip.zip ./*"
   },
   "dependencies": {
-    "@remnote/plugin-sdk": "latest",
+    "@remnote/plugin-sdk": "^0.0.46",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,6 +18,11 @@
       "type": "DescendantsOfName",
       "remName": "Goodreads Import",
       "level": "ReadCreateModify"
+    },
+    {
+      "type": "Powerup",
+      "powerupCode": "bookPowerup",
+      "level": "ReadCreateModify"
     }
   ],
   "unlisted": true

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,7 +15,8 @@
   "requestNative": false,
   "requiredScopes": [
     {
-      "type": "All",
+      "type": "DescendantsOfName",
+      "remName": "Goodreads Import",
       "level": "ReadCreateModify"
     }
   ],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,11 +18,6 @@
       "type": "DescendantsOfName",
       "remName": "Goodreads Import",
       "level": "ReadCreateModify"
-    },
-    {
-      "type": "Powerup",
-      "powerupCode": "bookPowerup",
-      "level": "ReadCreateModify"
     }
   ],
   "unlisted": true

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -151,11 +151,13 @@ async function fetchGoodreads(plugin: ReactRNPlugin) {
     await bookTag.addPowerup(BOOK_POWERUP_CODE);
 
     // Configure the Author(s) slot to use the Author tag as the select source
-    const authorsSlotRem = await bookTag.getPowerupPropertyAsRem(BOOK_POWERUP_CODE, AUTHORS_SLOT_CODE);
+    const authorsSlotRem = await plugin.powerup.getPowerupSlotByCode(BOOK_POWERUP_CODE, AUTHORS_SLOT_CODE);
     if (authorsSlotRem) {
       const authorTagRef = await plugin.richText.rem(authorTag).value();
       await authorsSlotRem.setPowerupProperty(BuiltInPowerupCodes.Slot, 'SelectTag', authorTagRef);
       doLog('Author(s) slot configured with Author tag as select source');
+    } else {
+      doError('Could not find Author(s) slot Rem to configure select source');
     }
 
     // Process each book


### PR DESCRIPTION
## Summary

- Creates "Book" and "Author" tag Rems under the "Goodreads Import" parent during sync
- Adds an "Author(s)" property to the Book tag using `setIsProperty`
- Each imported book is tagged with "Book" and linked to its author via `setTagPropertyValue`
- Authors are auto-created as document Rems, tagged with "Author", and deduplicated by name so multiple books by the same author share a single author Rem

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)